### PR TITLE
Update doc 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 python-ioctl
 ============
 
-This Python module contains some simple helper functions for calling `fcntl.ioctl()`_.
+This Python module contains some simple helper functions for calling `ioctl()`_.
 
-.. _`fcntl.ioctl()`: https://docs.python.org/3/library/fcntl.html#fcntl.ioctl
+.. _`ioctl()`: http://man7.org/linux/man-pages/man2/ioctl.2.html
 
 Example
 -------


### PR DESCRIPTION
The module do not call fcntl.ioctl() anymore. It's misleading today.